### PR TITLE
Fix newpost script frontmatter

### DIFF
--- a/scripts/newpost.cjs
+++ b/scripts/newpost.cjs
@@ -73,7 +73,7 @@ pubDate: '${postData.date}'
 heroImage: '/blog-placeholder.jpg'
 categories: [""]
 tags: [""]
-author: '["${postData.author}"]'
+authors: ["${postData.author}"]
 ---`);
     console.info(`\nSuccess!!: content/blog/${postData.fileName} was created`);
   }


### PR DESCRIPTION
## Summary
- update the newpost script to use the correct `authors` frontmatter key

## Testing
- `npm install`
- `npm run build` *(fails: Failed to parse image reference)*

------
https://chatgpt.com/codex/tasks/task_b_68406a821c2c83289554746be64ab8aa