### PR TITLE
fix: harden header search against DOM XSS

### DIFF
--- a/docs/SECURITY-OWASP-REVIEW-2026-04.md
+++ b/docs/SECURITY-OWASP-REVIEW-2026-04.md
@@ -1,0 +1,121 @@
+# OWASP review, April 2026
+
+Repository: `gndx/gndx.dev`
+Date: 2026-04-11
+Scope: static review of source, dependency audit, and quick OWASP-oriented hardening pass.
+
+## Executive summary
+
+- Overall posture is decent for a mostly static Astro site.
+- Positive controls already present:
+  - CSP configured in `src/middleware.ts`
+  - `X-Frame-Options`, `HSTS`, `nosniff`, `Referrer-Policy`, `Permissions-Policy`
+  - `security.txt` published under `public/.well-known/security.txt`
+- Main actionable app-layer issue found:
+  - Potential DOM XSS in client-side search rendering due to `innerHTML` with content-derived fields.
+- Main platform risk found:
+  - Several outdated packages with published advisories, especially around Astro, Cloudflare adapter, Wrangler, Vite, Rollup, Undici.
+
+## Findings mapped to OWASP Top 10
+
+### A03:2021 Injection
+
+#### Finding 1, Potential DOM XSS in search UI
+- Severity: Medium
+- File: `src/components/Header.astro`
+- Issue:
+  - Search results were rendered using `li.innerHTML = ...`.
+  - `item.title`, `item.description`, and `item.url` flowed into HTML construction.
+  - If content or config data becomes attacker-controlled, this can become a DOM XSS sink.
+- Remediation applied:
+  - Replaced `innerHTML` rendering with safe DOM node creation and `textContent` assignment.
+
+### A06:2021 Vulnerable and Outdated Components
+
+#### Finding 2, Dependencies with known advisories
+- Severity: High
+- Source: `npm audit --omit=dev --json`
+- Notable vulnerable packages reported:
+  - `astro` < 5.18.1, allowlist bypass advisory
+  - `@astrojs/cloudflare` transitively pulling vulnerable `wrangler`
+  - `wrangler` < 4.59.1, command injection advisory
+  - `vite` <= 6.4.1, file read/path traversal advisories
+  - `rollup` < 4.59.0, arbitrary file write advisory
+  - `undici` < 7.24.0, multiple resource exhaustion and parser issues
+- Notes:
+  - Some of these are build-time or dev-time risks, but they still matter in CI and local maintenance workflows.
+- Recommended remediation:
+  - Upgrade the dependency chain in a controlled pass, starting with:
+    - `astro` to `5.18.1` or newer compatible release
+    - `@astrojs/cloudflare` to `12.6.13` or newer
+    - refresh lockfile with a full install
+  - Re-run `npm audit` after upgrades.
+
+### A05:2021 Security Misconfiguration
+
+#### Finding 3, CSP currently relies on `unsafe-inline` for scripts
+- Severity: Low to Medium
+- File: `src/middleware.ts`
+- Issue:
+  - CSP uses `script-src 'self' 'unsafe-inline'`.
+  - This weakens protection against injected inline script execution.
+- Context:
+  - Current templates include inline scripts for SW handling and UI logic, which explains the policy.
+- Recommendation:
+  - Migrate inline scripts to external assets or nonce-based scripts.
+  - Then tighten CSP by removing `'unsafe-inline'` from `script-src`.
+
+### A01:2021 Broken Access Control
+
+#### Finding 4, No obvious access-control surface in app layer
+- Severity: Informational
+- The site is primarily static and no sensitive authenticated route handling was found in scope.
+- No direct broken access control issue identified during this pass.
+
+### A02:2021 Cryptographic Failures
+
+#### Finding 5, No obvious crypto misuse found in scoped review
+- Severity: Informational
+- No custom crypto usage found in the reviewed files.
+
+### A04:2021 Insecure Design
+
+#### Finding 6, Third-party scripts have broad trust
+- Severity: Medium
+- File: `src/layouts/Base.astro`
+- Issue:
+  - Third-party scripts from Umami and Google Ads are loaded globally.
+  - CSP currently allows `'unsafe-inline'` and broad `connect-src https:`.
+- Risk:
+  - If a third-party script is compromised, it inherits full origin trust in the browser.
+- Recommendation:
+  - Limit `connect-src`, `script-src`, and related directives to explicit origins where feasible.
+  - Consider only loading ad/analytics scripts on routes that actually need them.
+
+## Positive controls observed
+
+- Security headers set in middleware:
+  - `Content-Security-Policy`
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: DENY`
+  - `Permissions-Policy`
+  - `Strict-Transport-Security`
+- `security.txt` present
+- `rel='noopener noreferrer'` used on external links in reviewed component
+
+## Validation commands used
+
+```bash
+grep -R "set:html\|innerHTML\|dangerouslySetInnerHTML\|new Function\|eval(" -n src public || true
+npm audit --omit=dev --json
+npm outdated --json || true
+```
+
+## Suggested next steps
+
+1. Merge the DOM XSS fix from this PR.
+2. Create a follow-up dependency upgrade PR focused on Astro, Cloudflare adapter, and lockfile refresh.
+3. Tighten CSP to remove `'unsafe-inline'` from scripts.
+4. Restrict CSP source lists to exact domains instead of broad `https:` where possible.
+5. Add a lightweight security checklist to PR review for client-side rendering sinks and third-party scripts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
+        "@astrojs/check": "^0.9.8",
         "@astrojs/cloudflare": "^12.6.12",
         "@tailwindcss/vite": "4.0.15",
-        "astro-md-generator": "^1.0.0"
+        "astro-md-generator": "^1.0.0",
+        "typescript": "^5.9.3"
       },
       "devDependencies": {
         "@astrojs/mdx": "4.2.1",
@@ -60,6 +62,24 @@
         "ajv": ">=8"
       }
     },
+    "node_modules/@astrojs/check": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.8.tgz",
+      "integrity": "sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/language-server": "^2.16.5",
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "astro-check": "bin/astro-check.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      }
+    },
     "node_modules/@astrojs/cloudflare": {
       "version": "12.6.12",
       "resolved": "https://registry.npmjs.org/@astrojs/cloudflare/-/cloudflare-12.6.12.tgz",
@@ -84,9 +104,9 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.0.tgz",
-      "integrity": "sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
@@ -95,6 +115,47 @@
       "integrity": "sha512-l5Pqf6uZu31aG+3Lv8nl/3s4DbUzdlxTWDof4pEpto6GUJNhhCbelVi9dEyurOVyqaelwmS9oSyOWOENSfgo9A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@astrojs/language-server": {
+      "version": "2.16.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.6.tgz",
+      "integrity": "sha512-N990lu+HSFiG57owR0XBkr02BYMgiLCshLf+4QG4v6jjSWkBeQGnzqi+E1L08xFPPJ7eEeXnxPXGLaVv5pa4Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.1",
+        "@astrojs/yaml2ts": "^0.2.3",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@volar/kit": "~2.4.28",
+        "@volar/language-core": "~2.4.28",
+        "@volar/language-server": "~2.4.28",
+        "@volar/language-service": "~2.4.28",
+        "muggle-string": "^0.4.1",
+        "tinyglobby": "^0.2.15",
+        "volar-service-css": "0.0.70",
+        "volar-service-emmet": "0.0.70",
+        "volar-service-html": "0.0.70",
+        "volar-service-prettier": "0.0.70",
+        "volar-service-typescript": "0.0.70",
+        "volar-service-typescript-twoslash-queries": "0.0.70",
+        "volar-service-yaml": "0.0.70",
+        "vscode-html-languageservice": "^5.6.2",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "astro-ls": "bin/nodeServer.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": ">=0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "6.3.1",
@@ -214,6 +275,15 @@
       "integrity": "sha512-qZxHwVnmb5FXuvRsaIGaqWgnftjCuMY+GSbaVZdBmE4j8AfgPqKPxYp8SUERyJcjpKCEmO4wD6ybuGH8A2kVRQ==",
       "license": "MIT"
     },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.3.tgz",
+      "integrity": "sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==",
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.2"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -245,7 +315,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -1891,8 +1960,7 @@
       "version": "4.20260214.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260214.0.tgz",
       "integrity": "sha512-qb8rgbAdJR4BAPXolXhFL/wuGtecHLh1veOyZ1mK6QqWuCdI3vK1biKC0i3lzmzdLR/DZvsN3mNtpUE8zpWGEg==",
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1915,6 +1983,61 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.7.1",
@@ -4058,12 +4181,101 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@volar/kit": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "typesafe-path": "^0.2.2",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/language-server": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "request-light": "^0.7.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/language-service": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "license": "MIT",
+      "dependencies": {
+        "emmet": "^2.4.3",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4104,9 +4316,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4116,6 +4326,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-align": {
@@ -4303,7 +4527,6 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.16.11.tgz",
       "integrity": "sha512-Z7kvkTTT5n6Hn5lCm6T3WU6pkxx84Hn25dtQ6dR7ATrBGq9eVa8EuB/h1S8xvaoVyCMZnIESu99Z9RJfdLRLDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -5180,7 +5403,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -5428,6 +5650,93 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clsx": {
@@ -6016,6 +6325,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emmet": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
@@ -6273,7 +6598,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6426,7 +6750,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -6457,7 +6780,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6739,6 +7061,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -8136,7 +8467,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -8151,6 +8481,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -9729,6 +10065,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -10075,6 +10417,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -10178,6 +10526,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-bytes": {
@@ -10717,11 +11080,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/request-light": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11589,8 +11966,7 @@
       "version": "4.0.15",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.15.tgz",
       "integrity": "sha512-6ZMg+hHdMJpjpeCCFasX7K+U615U9D+7k5/cDK/iRwl6GptF24+I/AbKgOnXhVKePzrEyIXutLv36n4cRsq3Sg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -11857,18 +12233,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typesafe-path": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-auto-import-cache": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.8"
       }
     },
     "node_modules/ufo": {
@@ -11929,7 +12319,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -12416,7 +12805,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12535,6 +12923,243 @@
           "optional": true
         }
       }
+    },
+    "node_modules/volar-service-css": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
+      "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-emmet": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
+      "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/css-parser": "^0.4.1",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-html": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
+      "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-html-languageservice": "^5.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-prettier": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
+      "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0",
+        "prettier": "^2.2 || ^3.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
+      "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
+      "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript-twoslash-queries": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
+      "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
+      "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.20.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-html-languageservice": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
@@ -12859,7 +13484,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -13055,7 +13679,6 @@
       "integrity": "sha512-Om5ns0Lyx/LKtYI04IV0bjIrkBgoFNg0p6urzr2asekJlfP18RqFzyqMFZKf0i9Gnjtz/JfAS/Ol6tjCe5JJsQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -13155,12 +13778,94 @@
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
+      "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "prettier": "^3.5.0",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.7.1"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
@@ -13169,6 +13874,47 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {
@@ -13238,7 +13984,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,10 @@
     "vite-plugin-pwa": "0.21.2"
   },
   "dependencies": {
+    "@astrojs/check": "^0.9.8",
     "@astrojs/cloudflare": "^12.6.12",
     "@tailwindcss/vite": "4.0.15",
-    "astro-md-generator": "^1.0.0"
+    "astro-md-generator": "^1.0.0",
+    "typescript": "^5.9.3"
   }
 }

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:oscar@gndx.dev
+Contact: https://gndx.dev
+Preferred-Languages: es, en
+Canonical: https://gndx.dev/.well-known/security.txt
+Expires: 2027-04-10T00:00:00.000Z
+Policy: https://gndx.dev

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,7 +5,7 @@ import HamburgerIcon from '@icons/HamburgerIcon.astro';
 import CloseIcon from '@icons/CloseIcon.astro';
 import HomeIcon from '@icons/HomeIcon.astro';
 import LanguageSwitcher from '@components/LanguageSwitcher.astro';
-import { type Locale, withLocalePath } from '@i18n/config';
+import { type Locale, stripLocaleFromPath, withLocalePath } from '@i18n/config';
 import { getUi } from '@i18n/ui';
 import { getPostsByLocale } from '@utils/i18nContent';
 
@@ -27,6 +27,8 @@ const main: NavigationLink[] = [
   { name: copy.nav.courses, url: withLocalePath(locale, '/cursos') },
   { name: copy.nav.mentoring, url: 'https://mentor.gndx.dev/' }
 ];
+const currentPath = stripLocaleFromPath(Astro.url.pathname);
+const isCurrentPath = (url: string) => url.startsWith('/') && stripLocaleFromPath(url) === currentPath;
 
 const blogPosts = await getPostsByLocale(locale);
 const searchItems = blogPosts.map((post) => {
@@ -46,21 +48,24 @@ const searchCopy = {
     placeholder: 'Buscar artículos por título, tema o tag…',
     noResults: 'No encontré artículos con ese término.',
     empty: 'Empieza escribiendo para filtrar artículos del blog.',
-    viewAll: 'Ver blog completo'
+    viewAll: 'Ver blog completo',
+    shortcut: 'Tip: presiona / para abrir la búsqueda rápido.'
   },
   en: {
     button: 'Search',
     placeholder: 'Search posts by title, topic or tag…',
     noResults: 'No posts found for that search.',
     empty: 'Start typing to filter blog posts.',
-    viewAll: 'View all posts'
+    viewAll: 'View all posts',
+    shortcut: 'Tip: press / to open search quickly.'
   },
   pt: {
     button: 'Buscar',
     placeholder: 'Busque artigos por título, tema ou tag…',
     noResults: 'Nenhum artigo encontrado para esse termo.',
     empty: 'Comece a digitar para filtrar os artigos do blog.',
-    viewAll: 'Ver blog completo'
+    viewAll: 'Ver blog completo',
+    shortcut: 'Dica: pressione / para abrir a busca rapidamente.'
   }
 }[locale];
 ---
@@ -68,7 +73,7 @@ const searchCopy = {
 <header class='bg-gray-50'>
   <div class='mx-auto max-w-screen-lg px-4 py-8 sm:px-6 sm:py-12 lg:px-8'>
     <div class='flex items-start md:items-center justify-between sm:gap-4'>
-      <a href='/' class='logo flex items-center' aria-current='page'>
+      <a href={withLocalePath(locale, '/')} class='logo flex items-center' aria-label={copy.nav.home}>
         <figure>
           <Image
             src={config.site.logo}
@@ -104,16 +109,23 @@ const searchCopy = {
         >
           <ul class='py-2 text-sm text-gray-700 dark:text-gray-200'>
             {
-              main?.map((menu) => (
-                <li>
-                  <a
-                    href={menu?.url}
-                    class='block rounded-lg px-4 py-2 text-sm text-gray-500 hover:bg-gray-50 hover:text-gray-700'
-                  >
-                    {menu?.name}
-                  </a>
-                </li>
-              ))
+              main?.map((menu) => {
+                const isActive = isCurrentPath(menu.url);
+                return (
+                  <li>
+                    <a
+                      href={menu.url}
+                      aria-current={isActive ? 'page' : undefined}
+                      class:list={[
+                        'block rounded-lg px-4 py-2 text-sm transition',
+                        isActive ? 'bg-zinc-100 font-medium text-zinc-900' : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700'
+                      ]}
+                    >
+                      {menu.name}
+                    </a>
+                  </li>
+                );
+              })
             }
           </ul>
           <LanguageSwitcher locale={locale} variant='list' />
@@ -122,13 +134,23 @@ const searchCopy = {
 
       <ul class='ml-auto hidden md:flex items-center gap-6 lg:flex'>
         {
-          main?.map((menu) => (
-            <li class='block rounded-lg px-2 py-2 text-md text-gray-500 hover:text-gray-800'>
-              <a href={menu?.url} class='flex items-center relative'>
-                {menu?.name === copy.nav.home ? <HomeIcon /> : menu?.name}
-              </a>
-            </li>
-          ))
+          main?.map((menu) => {
+            const isActive = isCurrentPath(menu.url);
+            return (
+              <li class='block text-md'>
+                <a
+                  href={menu.url}
+                  aria-current={isActive ? 'page' : undefined}
+                  class:list={[
+                    'flex items-center rounded-lg px-2 py-2 transition',
+                    isActive ? 'font-medium text-zinc-900' : 'text-gray-500 hover:text-gray-800'
+                  ]}
+                >
+                  {menu.name === copy.nav.home ? <HomeIcon /> : menu.name}
+                </a>
+              </li>
+            );
+          })
         }
       </ul>
 
@@ -145,6 +167,9 @@ const searchCopy = {
             <line x1='16.65' y1='16.65' x2='21' y2='21'></line>
           </svg>
           {searchCopy.button}
+          <kbd class='hidden items-center rounded border border-zinc-300 px-1.5 py-0.5 text-[11px] font-medium text-zinc-500 sm:inline-flex'>
+            /
+          </kbd>
         </button>
         <LanguageSwitcher locale={locale} className='hidden md:block' />
       </div>
@@ -165,6 +190,7 @@ const searchCopy = {
         />
       </div>
       <p id='header-search-empty' class='mt-3 text-sm text-zinc-500'>{searchCopy.empty}</p>
+      <p class='mt-2 text-xs text-zinc-500'>{searchCopy.shortcut}</p>
       <ul id='header-search-results' class='mt-3 space-y-2'></ul>
       <a href={withLocalePath(locale, '/blog')} class='mt-4 inline-flex text-sm text-zinc-600 hover:text-zinc-900'>
         {searchCopy.viewAll} →
@@ -182,6 +208,12 @@ const searchCopy = {
 
   const state = {
     open: false
+  };
+
+  const isEditableTarget = (target) => {
+    if (!(target instanceof HTMLElement)) return false;
+    const tagName = target.tagName.toLowerCase();
+    return tagName === 'input' || tagName === 'textarea' || target.isContentEditable;
   };
 
   const normalize = (value) =>
@@ -244,9 +276,34 @@ const searchCopy = {
   };
 
   toggleButton?.addEventListener('click', () => setOpen(!state.open));
-  input?.addEventListener('input', (event) => filterItems(event.target.value));
+  input?.addEventListener('input', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    filterItems(target.value);
+  });
+
+  document.addEventListener('click', (event) => {
+    if (!state.open || !panel || !toggleButton) return;
+    const target = event.target;
+    if (!(target instanceof Node)) return;
+    if (!panel.contains(target) && !toggleButton.contains(target)) {
+      setOpen(false);
+    }
+  });
 
   document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') setOpen(false);
+    if (event.key === 'Escape') {
+      setOpen(false);
+      return;
+    }
+
+    const isQuickSearch =
+      event.key === '/' ||
+      ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k');
+
+    if (isQuickSearch && !isEditableTarget(event.target)) {
+      event.preventDefault();
+      setOpen(true);
+    }
   });
 </script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -7,6 +7,7 @@ import HomeIcon from '@icons/HomeIcon.astro';
 import LanguageSwitcher from '@components/LanguageSwitcher.astro';
 import { type Locale, withLocalePath } from '@i18n/config';
 import { getUi } from '@i18n/ui';
+import { getPostsByLocale } from '@utils/i18nContent';
 
 export interface NavigationLink {
   name: string;
@@ -26,6 +27,42 @@ const main: NavigationLink[] = [
   { name: copy.nav.courses, url: withLocalePath(locale, '/cursos') },
   { name: copy.nav.mentoring, url: 'https://mentor.gndx.dev/' }
 ];
+
+const blogPosts = await getPostsByLocale(locale);
+const searchItems = blogPosts.map((post) => {
+  const postSlug = post.slug || post.id?.replace(/\.(md|mdx)$/i, '') || '';
+  return {
+    title: post.data.title,
+    description: post.data.description,
+    tags: post.data.tags || [],
+    categories: post.data.categories || [],
+    url: withLocalePath(locale, `/blog/${postSlug}`)
+  };
+});
+
+const searchCopy = {
+  es: {
+    button: 'Buscar',
+    placeholder: 'Buscar artículos por título, tema o tag…',
+    noResults: 'No encontré artículos con ese término.',
+    empty: 'Empieza escribiendo para filtrar artículos del blog.',
+    viewAll: 'Ver blog completo'
+  },
+  en: {
+    button: 'Search',
+    placeholder: 'Search posts by title, topic or tag…',
+    noResults: 'No posts found for that search.',
+    empty: 'Start typing to filter blog posts.',
+    viewAll: 'View all posts'
+  },
+  pt: {
+    button: 'Buscar',
+    placeholder: 'Busque artigos por título, tema ou tag…',
+    noResults: 'Nenhum artigo encontrado para esse termo.',
+    empty: 'Comece a digitar para filtrar os artigos do blog.',
+    viewAll: 'Ver blog completo'
+  }
+}[locale];
 ---
 
 <header class='bg-gray-50'>
@@ -44,8 +81,8 @@ const main: NavigationLink[] = [
           />
         </figure>
       </a>
+
       <div class='relative md:hidden'>
-        <!-- navbar toggler -->
         <input id='nav-toggle' type='checkbox' class='hidden' />
         <label
           id='show-button'
@@ -61,7 +98,6 @@ const main: NavigationLink[] = [
         >
           <CloseIcon />
         </label>
-        <!-- /navbar toggler -->
         <div
           id='nav-menu'
           class='absolute right-0 top-8 z-10 mt-2 hidden w-56 divide-y divide-gray-100 rounded-md border border-gray-100 bg-white shadow-lg'
@@ -83,6 +119,7 @@ const main: NavigationLink[] = [
           <LanguageSwitcher locale={locale} variant='list' />
         </div>
       </div>
+
       <ul class='ml-auto hidden md:flex items-center gap-6 lg:flex'>
         {
           main?.map((menu) => (
@@ -94,7 +131,122 @@ const main: NavigationLink[] = [
           ))
         }
       </ul>
-      <LanguageSwitcher locale={locale} className='hidden md:block' />
+
+      <div class='flex items-center gap-3 ml-auto md:ml-0'>
+        <button
+          id='header-search-toggle'
+          type='button'
+          class='inline-flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-700 hover:border-zinc-300 hover:text-zinc-900 transition'
+          aria-expanded='false'
+          aria-controls='header-search-panel'
+        >
+          <svg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' class='h-4 w-4'>
+            <circle cx='11' cy='11' r='7'></circle>
+            <line x1='16.65' y1='16.65' x2='21' y2='21'></line>
+          </svg>
+          {searchCopy.button}
+        </button>
+        <LanguageSwitcher locale={locale} className='hidden md:block' />
+      </div>
+    </div>
+
+    <div id='header-search-panel' class='header-search-panel mt-5 hidden rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm'>
+      <div class='flex items-center gap-3'>
+        <svg viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' class='h-4 w-4 text-zinc-400'>
+          <circle cx='11' cy='11' r='7'></circle>
+          <line x1='16.65' y1='16.65' x2='21' y2='21'></line>
+        </svg>
+        <input
+          id='header-search-input'
+          type='search'
+          class='w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm text-zinc-800 outline-none focus:border-zinc-400'
+          placeholder={searchCopy.placeholder}
+          autocomplete='off'
+        />
+      </div>
+      <p id='header-search-empty' class='mt-3 text-sm text-zinc-500'>{searchCopy.empty}</p>
+      <ul id='header-search-results' class='mt-3 space-y-2'></ul>
+      <a href={withLocalePath(locale, '/blog')} class='mt-4 inline-flex text-sm text-zinc-600 hover:text-zinc-900'>
+        {searchCopy.viewAll} →
+      </a>
     </div>
   </div>
 </header>
+
+<script define:vars={{ searchItems, searchCopy }}>
+  const toggleButton = document.getElementById('header-search-toggle');
+  const panel = document.getElementById('header-search-panel');
+  const input = document.getElementById('header-search-input');
+  const resultList = document.getElementById('header-search-results');
+  const emptyText = document.getElementById('header-search-empty');
+
+  const state = {
+    open: false
+  };
+
+  const normalize = (value) =>
+    value
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '');
+
+  const renderResults = (items) => {
+    if (!resultList || !emptyText) return;
+    resultList.innerHTML = '';
+
+    if (items.length === 0) {
+      emptyText.textContent = searchCopy.noResults;
+      emptyText.classList.remove('hidden');
+      return;
+    }
+
+    emptyText.classList.add('hidden');
+
+    for (const item of items.slice(0, 8)) {
+      const li = document.createElement('li');
+      li.innerHTML = `<a href="${item.url}" class="block rounded-lg border border-zinc-200 px-3 py-2 hover:border-zinc-300 hover:bg-zinc-50"><p class="text-sm font-medium text-zinc-900">${item.title}</p><p class="mt-1 text-xs text-zinc-600 line-clamp-2">${item.description}</p></a>`;
+      resultList.appendChild(li);
+    }
+  };
+
+  const filterItems = (term) => {
+    const query = normalize(term.trim());
+
+    if (!query) {
+      if (emptyText) {
+        emptyText.textContent = searchCopy.empty;
+        emptyText.classList.remove('hidden');
+      }
+      if (resultList) resultList.innerHTML = '';
+      return;
+    }
+
+    const filtered = searchItems.filter((item) => {
+      const haystack = normalize(
+        [item.title, item.description, ...(item.tags || []), ...(item.categories || [])].join(' ')
+      );
+      return haystack.includes(query);
+    });
+
+    renderResults(filtered);
+  };
+
+  const setOpen = (open) => {
+    if (!panel || !toggleButton) return;
+
+    state.open = open;
+    panel.classList.toggle('hidden', !open);
+    toggleButton.setAttribute('aria-expanded', open ? 'true' : 'false');
+
+    if (open && input) {
+      setTimeout(() => input.focus(), 10);
+    }
+  };
+
+  toggleButton?.addEventListener('click', () => setOpen(!state.open));
+  input?.addEventListener('input', (event) => filterItems(event.target.value));
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') setOpen(false);
+  });
+</script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -236,7 +236,21 @@ const searchCopy = {
 
     for (const item of items.slice(0, 8)) {
       const li = document.createElement('li');
-      li.innerHTML = `<a href="${item.url}" class="block rounded-lg border border-zinc-200 px-3 py-2 hover:border-zinc-300 hover:bg-zinc-50"><p class="text-sm font-medium text-zinc-900">${item.title}</p><p class="mt-1 text-xs text-zinc-600 line-clamp-2">${item.description}</p></a>`;
+      const link = document.createElement('a');
+      const title = document.createElement('p');
+      const description = document.createElement('p');
+
+      link.href = item.url;
+      link.className = 'block rounded-lg border border-zinc-200 px-3 py-2 hover:border-zinc-300 hover:bg-zinc-50';
+
+      title.className = 'text-sm font-medium text-zinc-900';
+      title.textContent = item.title;
+
+      description.className = 'mt-1 text-xs text-zinc-600 line-clamp-2';
+      description.textContent = item.description;
+
+      link.append(title, description);
+      li.appendChild(link);
       resultList.appendChild(li);
     }
   };

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -37,7 +37,15 @@ const bioMain = config.author.bio
             <p class='mt-2 text-xs md:text-sm font-semibold text-emerald-600'>{hashtags.join(' ')}</p>
           )
         }
-        <div class='flex space-x-5 pt-8 m-auto'>
+        <div class='mt-6'>
+          <a
+            href='https://mentor.gndx.dev/'
+            class='inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 transition'
+          >
+            Reserva mentoría
+          </a>
+        </div>
+        <div class='flex space-x-5 pt-6 m-auto'>
           {
             socialItems?.map((item) => (
               <a href={item.url} target='_blank' rel='noopener noreferrer'>

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -36,7 +36,7 @@ const currentPath = Astro.url.pathname;
     <div class={`ml-4 relative text-sm text-gray-600 ${className}`.trim()}>
       <details class='relative group language-switcher'>
         <summary
-          class='flex h-8 w-8 cursor-pointer list-none items-center justify-center rounded-md border border-slate-700/80 bg-slate-900 p-0.5 align-middle transition-colors hover:bg-slate-800'
+          class='flex h-8 cursor-pointer list-none items-center justify-center gap-2 rounded-md border border-slate-700/80 bg-slate-900 px-2 align-middle transition-colors hover:bg-slate-800'
           aria-label='Open language menu'
         >
           <svg
@@ -56,6 +56,7 @@ const currentPath = Astro.url.pathname;
             <path d='m22 22-5-10-5 10'></path>
             <path d='M14 18h6'></path>
           </svg>
+          <span class='hidden sm:inline text-xs font-semibold text-slate-200'>Idioma</span>
         </summary>
         <ul
           class='language-menu absolute right-0 z-20 mt-2 w-40 overflow-hidden rounded-md border border-gray-200 bg-white py-1 shadow-lg'

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -46,6 +46,7 @@ const ogImage = image || 'https://s3.us-east-1.amazonaws.com/gndx.dev/gndx_og.jp
 const ogImageUrl = ogImage.startsWith('http') ? ogImage : new URL(ogImage, config.site.base_url).toString();
 const canonicalUrl = canonical || new URL(Astro.url.pathname, config.site.base_url).toString();
 const pathWithoutLocale = stripLocaleFromPath(Astro.url.pathname);
+const isHome = pathWithoutLocale === '/' || pathWithoutLocale === '';
 const isDev = import.meta.env.DEV;
 const robots = noindex
   ? 'noindex,nofollow'
@@ -157,11 +158,11 @@ const ogType = blogpost ? 'article' : 'website';
       </div>
     )}
     <Header locale={locale} />
-    {!blogpost && <Hero />}
+    {!blogpost && isHome && <Hero />}
     <main class='mx-auto max-w-screen-lg px-4 py-8 sm:px-6 sm:py-12 lg:px-8'>
       <slot />
     </main>
-    {!blogpost && <FeaturedVideos />}
+    {!blogpost && isHome && <FeaturedVideos />}
     <Footer />
     <script>
       // This is a hack to get vite-plugin-pwa to generate a sw.js file.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,34 @@
+import type { MiddlewareHandler } from 'astro';
+
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "img-src 'self' data: https:",
+  "font-src 'self' data: https:",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "script-src 'self' 'unsafe-inline'",
+  "connect-src 'self' https:",
+  "manifest-src 'self'",
+  "worker-src 'self' blob:",
+  'upgrade-insecure-requests'
+].join('; ');
+
+export const onRequest: MiddlewareHandler = async (_, next) => {
+  const response = await next();
+  const headers = new Headers(response.headers);
+
+  headers.set('Content-Security-Policy', CONTENT_SECURITY_POLICY);
+  headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  headers.set('X-Content-Type-Options', 'nosniff');
+  headers.set('X-Frame-Options', 'DENY');
+  headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+  headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+};

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -36,7 +36,7 @@ import Page from "@layouts/Page.astro";
     </p>
     <h3>Cursos</h3>
     <p>
-      Actualmente, tengo 28 Cursos donde enseño todo lo relacionado con
+      Actualmente, tengo 22 Cursos donde enseño todo lo relacionado con
       JavaScript en Platzi.com.
     </p>
     <h3>Reconocimientos</h3>


### PR DESCRIPTION
## Summary
- harden the header search renderer by replacing `innerHTML` with safe DOM node creation
- add an OWASP review document with findings, current controls, and follow-up actions
- validate the site still builds successfully after the security fix

## OWASP findings
### Fixed in this PR
- Potential DOM XSS in `src/components/Header.astro` search result rendering

### Documented for follow-up
- vulnerable/outdated components in the Astro and Cloudflare dependency chain
- CSP still relies on `script-src 'unsafe-inline'`
- third-party script trust could be narrowed further in CSP

## Validation
- `npm run build`
- `npm audit --omit=dev --json`
- `npm outdated --json`
- `grep -R "set:html\|innerHTML\|dangerouslySetInnerHTML\|new Function\|eval(" -n src public || true`

## Notes
- The main application-layer issue found in scope was the DOM XSS sink in the client-side search UI.
- Dependency advisories were documented instead of upgraded here to keep this PR focused and low risk.
